### PR TITLE
Update Package.swift platforms and dependency versions

### DIFF
--- a/FrescoCLI/Package.swift
+++ b/FrescoCLI/Package.swift
@@ -4,11 +4,11 @@ import PackageDescription
 let package = Package(
     name: "FrescoCLI",
     platforms: [
-        .macOS(.v15),
+        .macOS(.v26),
     ],
     dependencies: [
         .package(path: "../FrescoCore"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.1"),
     ],
     targets: [
         .executableTarget(

--- a/FrescoCore/Package.swift
+++ b/FrescoCore/Package.swift
@@ -4,8 +4,7 @@ import PackageDescription
 let package = Package(
     name: "FrescoCore",
     platforms: [
-        .macOS(.v15),
-        .iOS(.v18)
+        .macOS(.v26),
     ],
     products: [
         .library(name: "FrescoCore", targets: ["FrescoCore"]),


### PR DESCRIPTION
## Summary
- FrescoCore: target macOS 26 only, remove iOS platform
- FrescoCLI: target macOS 26, bump swift-argument-parser to 1.7.1
- `swift build` succeeds in both packages

Closes #10