### PR TITLE
FrescoError enum + GenerationResult model

### DIFF
--- a/FrescoCore/Sources/FrescoCore/Models/FrescoError.swift
+++ b/FrescoCore/Sources/FrescoCore/Models/FrescoError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum FrescoError: Error, Sendable, Codable {
+public enum FrescoError: Error, Sendable, Codable {
     case geminiError(String)
     case r2UploadError(String)
     case configurationError(String)

--- a/FrescoCore/Sources/FrescoCore/Models/GenerationResult.swift
+++ b/FrescoCore/Sources/FrescoCore/Models/GenerationResult.swift
@@ -1,9 +1,17 @@
 import Foundation
 
-struct GenerationResult: Sendable, Codable {
-    let date: Date
-    let prompt: String
-    let imageData: Data
-    let r2Key: String
-    let publicURL: URL
+public struct GenerationResult: Sendable, Codable {
+    public let date: Date
+    public let prompt: String
+    public let imageData: Data
+    public let r2Key: String
+    public let publicURL: URL
+
+    public init(date: Date, prompt: String, imageData: Data, r2Key: String, publicURL: URL) {
+        self.date = date
+        self.prompt = prompt
+        self.imageData = imageData
+        self.r2Key = r2Key
+        self.publicURL = publicURL
+    }
 }

--- a/FrescoCore/Tests/FrescoCoreTests/Models/GenerationResultTests.swift
+++ b/FrescoCore/Tests/FrescoCoreTests/Models/GenerationResultTests.swift
@@ -23,6 +23,44 @@ struct GenerationResultTests {
         #expect(result.publicURL == url)
     }
 
+    @Test func generationResult_codableRoundTrip() throws {
+        let date = Date()
+        let data = Data([1, 2, 3])
+        let url = URL(string: "https://example.com/test/image.jpg")!
+
+        let original = GenerationResult(
+            date: date,
+            prompt: "a test prompt",
+            imageData: data,
+            r2Key: "test/image.jpg",
+            publicURL: url
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(GenerationResult.self, from: encoded)
+
+        #expect(decoded.date == date)
+        #expect(decoded.prompt == "a test prompt")
+        #expect(decoded.imageData == data)
+        #expect(decoded.r2Key == "test/image.jpg")
+        #expect(decoded.publicURL == url)
+    }
+
+    @Test func frescoError_codableRoundTrip() throws {
+        let cases: [FrescoError] = [
+            .geminiError("gemini fail"),
+            .r2UploadError("r2 fail"),
+            .configurationError("config fail"),
+            .serverModeNotImplemented,
+        ]
+
+        for error in cases {
+            let encoded = try JSONEncoder().encode(error)
+            let decoded = try JSONDecoder().decode(FrescoError.self, from: encoded)
+            #expect(String(describing: decoded) == String(describing: error))
+        }
+    }
+
     @Test func frescoError_casesAreDistinct() {
         let gemini = FrescoError.geminiError("fail")
         let r2 = FrescoError.r2UploadError("fail")


### PR DESCRIPTION
## Summary

- Add `FrescoError` typed error enum with cases for Gemini, R2, configuration, and server-mode errors
- Add `GenerationResult` value type for generation cycle results
- Both types are `Sendable` and `Codable`

Closes #24

## Test plan

- [x] `GenerationResultTests.generationResult_storesAllProperties` verifies all properties round-trip
- [x] `GenerationResultTests.frescoError_casesAreDistinct` verifies each error case matches correctly
- [x] `swift test --package-path FrescoCore` passes