### PR TITLE
GeminiClientProtocol + failing tests

### DIFF
--- a/FrescoCore/Sources/FrescoCore/Clients/GeminiClientProtocol.swift
+++ b/FrescoCore/Sources/FrescoCore/Clients/GeminiClientProtocol.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol GeminiClientProtocol: Sendable {
-    func generateImage(prompt: String) async throws -> Data
+    func generateImage(prompt: String) async throws(FrescoError) -> Data
 }

--- a/FrescoCore/Tests/FrescoCoreTests/Clients/GeminiClientProtocolTests.swift
+++ b/FrescoCore/Tests/FrescoCoreTests/Clients/GeminiClientProtocolTests.swift
@@ -6,7 +6,7 @@ struct GeminiClientProtocolTests {
     struct MockGeminiClient: GeminiClientProtocol {
         let result: Data
 
-        func generateImage(prompt: String) async throws -> Data {
+        func generateImage(prompt: String) async throws(FrescoError) -> Data {
             result
         }
     }


### PR DESCRIPTION
## Summary
- Add `GeminiClientProtocol` with a single `generateImage(prompt:)` method
- Add failing tests committed before implementation
- Mock conformance validates protocol requirements and Sendable conformance

Closes #25