### PR TITLE
ReadmeUpdater + tests

### DIFF
--- a/FrescoCLI/Sources/FrescoCLI/Utilities/ReadmeUpdater.swift
+++ b/FrescoCLI/Sources/FrescoCLI/Utilities/ReadmeUpdater.swift
@@ -9,11 +9,19 @@ struct ReadmeUpdater: Sendable {
         var lines = content.components(separatedBy: "\n")
 
         if let markerIndex = lines.firstIndex(where: { $0.contains(marker) }) {
-            let nextIndex = markerIndex + 1
-            if nextIndex < lines.count && lines[nextIndex].hasPrefix("![Fresco](") {
-                lines[nextIndex] = imageLine
+            // Find existing Fresco image line after marker, skipping blank lines
+            var imageIndex: Int?
+            for i in (markerIndex + 1)..<lines.count {
+                let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
+                if trimmed.isEmpty { continue }
+                if trimmed.hasPrefix("![Fresco](") { imageIndex = i }
+                break
+            }
+
+            if let imageIndex {
+                lines[imageIndex] = imageLine
             } else {
-                lines.insert(imageLine, at: nextIndex)
+                lines.insert(imageLine, at: markerIndex + 1)
             }
         } else {
             // Insert after the first line (title)

--- a/FrescoCLI/Tests/FrescoCLITests/ReadmeUpdaterTests.swift
+++ b/FrescoCLI/Tests/FrescoCLITests/ReadmeUpdaterTests.swift
@@ -20,9 +20,10 @@ struct ReadmeUpdaterTests {
 
         try updater.insertImageURL(in: tmp, imageURL: imageURL)
 
-        let result = try String(contentsOfFile: tmp, encoding: .utf8)
-        #expect(result.contains("<!-- Fresco image -->"))
-        #expect(result.contains("![Fresco](https://pub-xxx.r2.dev/fresco/today.jpg)"))
+        let lines = try String(contentsOfFile: tmp, encoding: .utf8).components(separatedBy: "\n")
+        let markerIndex = lines.firstIndex(where: { $0.contains("<!-- Fresco image -->") })
+        #expect(markerIndex != nil)
+        #expect(lines[markerIndex! + 1] == "![Fresco](https://pub-xxx.r2.dev/fresco/today.jpg)")
     }
 
     @Test func insertImageURL_replacesExistingImage() throws {
@@ -40,9 +41,32 @@ struct ReadmeUpdaterTests {
 
         try updater.insertImageURL(in: tmp, imageURL: imageURL)
 
-        let result = try String(contentsOfFile: tmp, encoding: .utf8)
-        #expect(!result.contains("old-url.example.com"))
-        #expect(result.contains("![Fresco](https://pub-xxx.r2.dev/fresco/today.jpg)"))
+        let lines = try String(contentsOfFile: tmp, encoding: .utf8).components(separatedBy: "\n")
+        #expect(!lines.contains(where: { $0.contains("old-url.example.com") }))
+        let markerIndex = lines.firstIndex(where: { $0.contains("<!-- Fresco image -->") })
+        #expect(markerIndex != nil)
+        #expect(lines[markerIndex! + 1] == "![Fresco](https://pub-xxx.r2.dev/fresco/today.jpg)")
+    }
+
+    @Test func insertImageURL_replacesExistingImage_withBlankLineAfterMarker() throws {
+        let tmp = NSTemporaryDirectory() + "readme-blankline-\(UUID().uuidString).md"
+        let content = """
+            # My Project
+
+            <!-- Fresco image -->
+
+            ![Fresco](https://old-url.example.com/old.jpg)
+
+            Some other content.
+            """
+        try content.write(toFile: tmp, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        try updater.insertImageURL(in: tmp, imageURL: imageURL)
+
+        let lines = try String(contentsOfFile: tmp, encoding: .utf8).components(separatedBy: "\n")
+        #expect(!lines.contains(where: { $0.contains("old-url.example.com") }))
+        #expect(lines.contains(where: { $0 == "![Fresco](https://pub-xxx.r2.dev/fresco/today.jpg)" }))
     }
 
     @Test func insertImageURL_noMarker_addsMarkerAndImage() throws {
@@ -57,8 +81,9 @@ struct ReadmeUpdaterTests {
 
         try updater.insertImageURL(in: tmp, imageURL: imageURL)
 
-        let result = try String(contentsOfFile: tmp, encoding: .utf8)
-        #expect(result.contains("<!-- Fresco image -->"))
-        #expect(result.contains("![Fresco](https://pub-xxx.r2.dev/fresco/today.jpg)"))
+        let lines = try String(contentsOfFile: tmp, encoding: .utf8).components(separatedBy: "\n")
+        let markerIndex = lines.firstIndex(where: { $0.contains("<!-- Fresco image -->") })
+        #expect(markerIndex != nil)
+        #expect(lines[markerIndex! + 1] == "![Fresco](https://pub-xxx.r2.dev/fresco/today.jpg)")
     }
 }


### PR DESCRIPTION
## Summary

- Add `ReadmeUpdater` utility that inserts or replaces a Fresco image URL in README.md using a `<!-- Fresco image -->` marker comment
- If no marker exists, it's added after the title line
- Tests cover insert, replace, and no-marker scenarios

Closes #38

## Test plan

- [x] `swift test --package-path FrescoCLI` passes (13 tests)
- [ ] CI passes on macOS and Linux