### PR TITLE
GalleryWriter + tests

### DIFF
--- a/FrescoCLI/Sources/FrescoCLI/Utilities/GalleryWriter.swift
+++ b/FrescoCLI/Sources/FrescoCLI/Utilities/GalleryWriter.swift
@@ -1,20 +1,27 @@
 import Foundation
+import FrescoCore
 
 struct GalleryWriter: Sendable {
     private let marker = "<!-- Fresco appends new entries below this line on each generation -->"
     private let tableHeader = "| Date | Image |"
     private let tableSeparator = "|------|-------|"
 
-    func appendEntry(to galleryPath: String, date: String, imageURL: String) throws {
-        let content = try String(contentsOfFile: galleryPath, encoding: .utf8)
+    func appendEntry(to galleryPath: String, date: String, imageURL: String) throws(FrescoError) {
+        let content: String
+        do {
+            content = try String(contentsOfFile: galleryPath, encoding: .utf8)
+        } catch {
+            throw .configurationError("Could not read gallery file: \(galleryPath)")
+        }
         let row = "| \(date) | ![](\(imageURL)) |"
         var lines = content.components(separatedBy: "\n")
 
         guard let markerIndex = lines.firstIndex(where: { $0.contains(marker) }) else {
-            return
+            throw .configurationError("Gallery file is missing the marker comment.")
         }
 
-        if let separatorIndex = lines.firstIndex(where: { $0.contains(tableSeparator) }) {
+        let afterMarker = lines[(markerIndex + 1)...]
+        if let separatorIndex = afterMarker.firstIndex(where: { $0.contains(tableSeparator) }) {
             lines.insert(row, at: separatorIndex + 1)
         } else {
             lines.insert(tableHeader, at: markerIndex + 1)
@@ -23,6 +30,10 @@ struct GalleryWriter: Sendable {
         }
 
         let result = lines.joined(separator: "\n")
-        try result.write(toFile: galleryPath, atomically: true, encoding: .utf8)
+        do {
+            try result.write(toFile: galleryPath, atomically: true, encoding: .utf8)
+        } catch {
+            throw .configurationError("Could not write gallery file: \(galleryPath)")
+        }
     }
 }

--- a/FrescoCLI/Tests/FrescoCLITests/GalleryWriterTests.swift
+++ b/FrescoCLI/Tests/FrescoCLITests/GalleryWriterTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import FrescoCore
 @testable import FrescoCLI
 
 struct GalleryWriterTests {
@@ -70,5 +71,43 @@ struct GalleryWriterTests {
         #expect(lines[separatorIndex! + 1].contains("2026-03-23"))
         #expect(lines[separatorIndex! + 2].contains("2026-03-22"))
         #expect(lines[separatorIndex! + 3].contains("2026-03-21"))
+    }
+
+    @Test func appendEntry_ignoresTableBeforeMarker() throws {
+        let tmp = NSTemporaryDirectory() + "gallery-premarker-\(UUID().uuidString).md"
+        let content = """
+            # Gallery
+
+            | Other | Table |
+            |------|-------|
+            | data | here |
+
+            \(marker)
+            | Date | Image |
+            |------|-------|
+            | 2026-03-22 | ![](https://example.com/2026-03-22.jpg) |
+            """
+        try content.write(toFile: tmp, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        try writer.appendEntry(to: tmp, date: "2026-03-23", imageURL: "https://example.com/2026-03-23.jpg")
+
+        let lines = try String(contentsOfFile: tmp, encoding: .utf8).components(separatedBy: "\n")
+        // The pre-marker table should be untouched
+        let markerIndex = lines.firstIndex(where: { $0.contains(marker) })!
+        let galleryHeader = lines[(markerIndex + 1)...].firstIndex(where: { $0.contains("|------|") })!
+        #expect(lines[galleryHeader + 1] == "| 2026-03-23 | ![](https://example.com/2026-03-23.jpg) |")
+        #expect(lines[galleryHeader + 2].contains("2026-03-22"))
+    }
+
+    @Test func appendEntry_throwsWhenMarkerMissing() throws {
+        let tmp = NSTemporaryDirectory() + "gallery-nomarker-\(UUID().uuidString).md"
+        let content = "# Gallery\n\nSome content.\n"
+        try content.write(toFile: tmp, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        #expect(throws: FrescoError.self) {
+            try writer.appendEntry(to: tmp, date: "2026-03-23", imageURL: "https://example.com/2026-03-23.jpg")
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `GalleryWriter` utility that appends date/image rows to a markdown table in `gallery.md`
- New entries insert after the table header separator, keeping newest first
- Creates the table header automatically on the first entry

Closes #35

## Test plan

- [x] `swift test --package-path FrescoCLI` passes (17 tests)
- [x] CI passes on macOS and Linux