### PR TITLE
Add release build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
             runner: macos-26
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Build and package binary
         run: |
@@ -50,6 +52,8 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Build and package binary
         run: |


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` triggered on `v*` tags
- Builds release binaries for macOS (arm64, x86_64) and Linux (arm64, x86_64)
- Creates a GitHub Release with all artifacts and auto-generated notes
- Updates the Homebrew tap formula at `argylebits/homebrew-tap`

Closes #63

## Test plan
- [ ] Push a `v*` tag and verify the workflow triggers
- [ ] Confirm all four platform/arch builds succeed
- [ ] Confirm the GitHub Release is created with correct artifacts
- [ ] Confirm the Homebrew formula is updated in the tap repo