### PR TITLE
Fix release: build before --show-bin-path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Build and package binary
         run: |
+          swift build -c release --package-path FrescoCLI --arch ${{ matrix.arch }}
           BIN_PATH=$(swift build -c release --package-path FrescoCLI --arch ${{ matrix.arch }} --show-bin-path)
           mkdir -p staging
           cp "$BIN_PATH/FrescoCLI" staging/fresco
@@ -57,6 +58,7 @@ jobs:
 
       - name: Build and package binary
         run: |
+          swift build -c release --package-path FrescoCLI
           BIN_PATH=$(swift build -c release --package-path FrescoCLI --show-bin-path)
           mkdir -p staging
           cp "$BIN_PATH/FrescoCLI" staging/fresco


### PR DESCRIPTION
## Summary
- `--show-bin-path` only prints the output directory without building
- Add explicit `swift build` before the `--show-bin-path` call so the binary exists when we copy it

## Test plan
- [ ] Release workflow builds successfully on all platforms