### PR TITLE
Add checkout to release job for generate-notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,8 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts


### PR DESCRIPTION
## Summary
- `gh release create --generate-notes` requires a git repo to generate release notes
- The checkout step was previously removed per Copilot suggestion, but it's needed for this
- Adds it back to the release job only

## Test plan
- [ ] Release workflow creates GitHub release with generated notes