### PR TITLE
Add fresco.yml workflow: generate, upload, copy to latest, update gallery

### DIFF
--- a/.github/workflows/fresco.yml
+++ b/.github/workflows/fresco.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: fresco
+  cancel-in-progress: true
+
 jobs:
   fresco:
     name: Generate and publish

--- a/.github/workflows/fresco.yml
+++ b/.github/workflows/fresco.yml
@@ -62,9 +62,11 @@ jobs:
           URL="${{ steps.fresco.outputs.url }}"
           DATE="$(date -u +%Y-%m-%d)"
           ROW="| ${DATE} | ![]($URL) |"
-          sed -i.bak "/^|------|-------|$/a\\
-          $ROW" gallery.md
-          rm -f gallery.md.bak
+          awk -v row="$ROW" '
+            { print }
+            /^\|------\|-------\|$/ { print row }
+          ' gallery.md > gallery.md.tmp
+          mv gallery.md.tmp gallery.md
 
       - name: Open PR with gallery update
         run: |

--- a/.github/workflows/fresco.yml
+++ b/.github/workflows/fresco.yml
@@ -1,0 +1,81 @@
+name: Fresco
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fresco:
+    name: Generate and publish
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Fresco
+        run: brew install argylebits/tap/fresco
+
+      - name: Generate and upload
+        id: fresco
+        run: |
+          IMAGE=$(fresco generate)
+          echo "url=$(fresco upload "$IMAGE")" >> "$GITHUB_OUTPUT"
+        env:
+          GEMINI_API_KEY:      ${{ secrets.GEMINI_API_KEY }}
+          FRESCO_PROMPT:       ${{ secrets.FRESCO_PROMPT }}
+          FRESCO_SLUG:         ${{ secrets.FRESCO_SLUG }}
+          R2_ACCOUNT_ID:       ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID:    ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET:           ${{ secrets.R2_BUCKET }}
+          R2_PUBLIC_BASE_URL:  ${{ secrets.R2_PUBLIC_BASE_URL }}
+
+      - name: Copy to stable latest URL
+        run: |
+          URL="${{ steps.fresco.outputs.url }}"
+          FILENAME=$(basename "$URL")
+          fresco remote copy "$FILENAME" "latest.${FILENAME##*.}"
+        env:
+          FRESCO_SLUG:         ${{ secrets.FRESCO_SLUG }}
+          R2_ACCOUNT_ID:       ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID:    ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET:           ${{ secrets.R2_BUCKET }}
+          R2_PUBLIC_BASE_URL:  ${{ secrets.R2_PUBLIC_BASE_URL }}
+
+      - name: Purge GitHub camo cache
+        if: vars.CAMO_IMAGE_URL != ''
+        run: curl -sX PURGE "${{ vars.CAMO_IMAGE_URL }}"
+
+      - name: Append gallery entry
+        run: |
+          URL="${{ steps.fresco.outputs.url }}"
+          DATE="$(date -u +%Y-%m-%d)"
+          echo "| ${DATE} | ![]($URL) |" >> gallery.md
+
+      - name: Open PR with gallery update
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add gallery.md
+          if git diff --staged --quiet; then
+            echo "No changes."
+            exit 0
+          fi
+          DATE="$(date -u +%Y-%m-%d)"
+          BRANCH="fresco/gallery-${DATE}-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          git commit -m "fresco: gallery ${DATE}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "fresco: gallery ${DATE}" \
+            --body "Automated gallery update." \
+            --base "${{ github.event.repository.default_branch }}" \
+            --head "$BRANCH"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fresco.yml
+++ b/.github/workflows/fresco.yml
@@ -24,7 +24,8 @@ jobs:
         id: fresco
         run: |
           IMAGE=$(fresco generate)
-          echo "url=$(fresco upload "$IMAGE")" >> "$GITHUB_OUTPUT"
+          URL=$(fresco upload "$IMAGE")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
         env:
           GEMINI_API_KEY:      ${{ secrets.GEMINI_API_KEY }}
           FRESCO_PROMPT:       ${{ secrets.FRESCO_PROMPT }}
@@ -39,7 +40,7 @@ jobs:
         run: |
           URL="${{ steps.fresco.outputs.url }}"
           FILENAME=$(basename "$URL")
-          fresco remote copy "$FILENAME" "latest.${FILENAME##*.}"
+          fresco remote copy "$FILENAME" "latest"
         env:
           FRESCO_SLUG:         ${{ secrets.FRESCO_SLUG }}
           R2_ACCOUNT_ID:       ${{ secrets.R2_ACCOUNT_ID }}

--- a/.github/workflows/fresco.yml
+++ b/.github/workflows/fresco.yml
@@ -57,11 +57,14 @@ jobs:
         if: vars.CAMO_IMAGE_URL != ''
         run: curl -sX PURGE "${{ vars.CAMO_IMAGE_URL }}"
 
-      - name: Append gallery entry
+      - name: Add gallery entry (newest first)
         run: |
           URL="${{ steps.fresco.outputs.url }}"
           DATE="$(date -u +%Y-%m-%d)"
-          echo "| ${DATE} | ![]($URL) |" >> gallery.md
+          ROW="| ${DATE} | ![]($URL) |"
+          sed -i.bak "/^|------|-------|$/a\\
+          $ROW" gallery.md
+          rm -f gallery.md.bak
 
       - name: Open PR with gallery update
         run: |

--- a/Examples/SETUP.md
+++ b/Examples/SETUP.md
@@ -53,7 +53,10 @@ The step snippets expect the upload URL as a GitHub Actions output. Set up your 
 ```yaml
 - name: Generate and upload
   id: fresco
-  run: echo "url=$(fresco upload $(fresco generate))" >> "$GITHUB_OUTPUT"
+  run: |
+    IMAGE=$(fresco generate)
+    URL=$(fresco upload "$IMAGE")
+    echo "url=$URL" >> "$GITHUB_OUTPUT"
   env:
     # ... all secrets
 ```
@@ -64,7 +67,7 @@ The readme snippet uses an HTML comment as a marker. For example:
 
 ```markdown
 <!-- Fresco image -->
-![Fresco](https://your-r2-domain.dev/your-slug/latest.png)
+![Fresco](https://your-r2-domain.dev/your-slug/latest)
 ```
 
 The marker can be whatever you want — just keep it in sync with the `sed` pattern in your workflow.

--- a/Examples/SETUP.md
+++ b/Examples/SETUP.md
@@ -44,6 +44,7 @@ Add these steps after the generate-and-upload step in any workflow above.
 - `steps-update-readme.yml` — replaces the image line after a marker in your README
 - `steps-update-gallery.yml` — appends a row to a markdown table
 - `steps-latest-alias.yml` — copies the image to a stable `latest.{ext}` URL on R2 using `fresco remote copy` (extension is preserved from the uploaded filename), then purges the GitHub camo cache
+- `steps-latest-extensionless.yml` — same as above but copies to an extensionless `latest` URL, avoiding any format/extension mismatch (R2 serves the correct `Content-Type` from the source object's metadata)
 
 ## Capturing the URL
 

--- a/Examples/steps-latest-alias.yml
+++ b/Examples/steps-latest-alias.yml
@@ -8,7 +8,10 @@
 #
 #   - name: Generate and upload
 #     id: fresco
-#     run: echo "url=$(fresco upload $(fresco generate))" >> "$GITHUB_OUTPUT"
+#     run: |
+#       IMAGE=$(fresco generate)
+#       URL=$(fresco upload "$IMAGE")
+#       echo "url=$URL" >> "$GITHUB_OUTPUT"
 #     env: ...
 #
 # GitHub camo cache:

--- a/Examples/steps-latest-extensionless.yml
+++ b/Examples/steps-latest-extensionless.yml
@@ -1,0 +1,46 @@
+# Copy the uploaded image to a stable, extensionless URL like:
+#   https://your-r2-domain.dev/your-slug/latest
+#
+# Using an extensionless destination avoids any mismatch between the
+# URL and the actual image format. R2 serves the correct Content-Type
+# from the source object's metadata, so browsers render it correctly.
+#
+# The generate-and-upload step must capture the URL as an output:
+#
+#   - name: Generate and upload
+#     id: fresco
+#     run: |
+#       IMAGE=$(fresco generate)
+#       URL=$(fresco upload "$IMAGE")
+#       echo "url=$URL" >> "$GITHUB_OUTPUT"
+#     env: ...
+#
+# GitHub camo cache:
+#   GitHub proxies external images through camo.githubusercontent.com and
+#   caches them aggressively. The purge step below clears the cache so
+#   GitHub picks up the new image.
+#
+#   To set CAMO_IMAGE_URL:
+#     1. Push your README with the latest image reference
+#     2. Open your README on GitHub
+#     3. Right-click the image → "Copy image address"
+#     4. Save that URL as a repository variable named CAMO_IMAGE_URL
+#
+#   See: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls#removing-an-image-from-camos-cache
+
+      - name: Copy to stable latest URL
+        run: |
+          URL="${{ steps.fresco.outputs.url }}"
+          FILENAME=$(basename "$URL")
+          fresco remote copy "$FILENAME" latest
+        env:
+          FRESCO_SLUG:           ${{ secrets.FRESCO_SLUG }}
+          R2_ACCOUNT_ID:         ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID:      ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY:  ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET:             ${{ secrets.R2_BUCKET }}
+          R2_PUBLIC_BASE_URL:    ${{ secrets.R2_PUBLIC_BASE_URL }}
+
+      - name: Purge GitHub camo cache
+        if: vars.CAMO_IMAGE_URL != ''
+        run: curl -sX PURGE "${{ vars.CAMO_IMAGE_URL }}"

--- a/Examples/steps-update-gallery.yml
+++ b/Examples/steps-update-gallery.yml
@@ -13,11 +13,14 @@
 #     contents: write
 #     pull-requests: write
 
-      - name: Append gallery entry
+      - name: Add gallery entry (newest first)
         run: |
           URL="${{ steps.fresco.outputs.url }}"
-          DATE="$(date +%Y-%m-%d)"
-          echo "| ${DATE} | ![]($URL) |" >> gallery.md
+          DATE="$(date -u +%Y-%m-%d)"
+          ROW="| ${DATE} | ![]($URL) |"
+          sed -i.bak "/^|------|-------|$/a\\
+          $ROW" gallery.md
+          rm -f gallery.md.bak
 
       - name: Open PR with update
         run: |

--- a/Examples/steps-update-gallery.yml
+++ b/Examples/steps-update-gallery.yml
@@ -4,7 +4,10 @@
 #
 #   - name: Generate and upload
 #     id: fresco
-#     run: echo "url=$(fresco upload $(fresco generate))" >> "$GITHUB_OUTPUT"
+#     run: |
+#       IMAGE=$(fresco generate)
+#       URL=$(fresco upload "$IMAGE")
+#       echo "url=$URL" >> "$GITHUB_OUTPUT"
 #     env: ...
 #
 # Your workflow must include these permissions:

--- a/Examples/steps-update-gallery.yml
+++ b/Examples/steps-update-gallery.yml
@@ -18,9 +18,11 @@
           URL="${{ steps.fresco.outputs.url }}"
           DATE="$(date -u +%Y-%m-%d)"
           ROW="| ${DATE} | ![]($URL) |"
-          sed -i.bak "/^|------|-------|$/a\\
-          $ROW" gallery.md
-          rm -f gallery.md.bak
+          awk -v row="$ROW" '
+            { print }
+            /^\|------\|-------\|$/ { print row }
+          ' gallery.md > gallery.md.tmp
+          mv gallery.md.tmp gallery.md
 
       - name: Open PR with update
         run: |

--- a/Examples/steps-update-readme.yml
+++ b/Examples/steps-update-readme.yml
@@ -4,7 +4,10 @@
 #
 #   - name: Generate and upload
 #     id: fresco
-#     run: echo "url=$(fresco upload $(fresco generate))" >> "$GITHUB_OUTPUT"
+#     run: |
+#       IMAGE=$(fresco generate)
+#       URL=$(fresco upload "$IMAGE")
+#       echo "url=$URL" >> "$GITHUB_OUTPUT"
 #     env: ...
 #
 # Your workflow must include these permissions:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- Fresco image -->
-![Fresco](https://pub-d60dc12417c74d04b3dd6a1ed43e02c4.r2.dev/fresco/latest.png)
+![Fresco](https://pub-d60dc12417c74d04b3dd6a1ed43e02c4.r2.dev/fresco/latest)
 
 # Fresco
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- Fresco image -->
-![Fresco](https://pub-d60dc12417c74d04b3dd6a1ed43e02c4.r2.dev/fresco/2026-03-25-141039.jpg)
+![Fresco](https://pub-d60dc12417c74d04b3dd6a1ed43e02c4.r2.dev/fresco/latest.png)
 
 # Fresco
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/fresco.yml` — runs after every successful Release workflow to generate a fresh image, upload to R2, copy to an extensionless `latest` alias, purge the GitHub camo cache, and open a PR to append the new image to `gallery.md`
- Updates README banner to use the stable extensionless `latest` URL instead of a hardcoded dated image
- Adds `Examples/steps-latest-extensionless.yml` — example workflow step for extensionless stable aliases

Closes #119