### PR TITLE
Preserve source Content-Type when copy uses REPLACE

### DIFF
--- a/FrescoCore/Sources/FrescoCore/Clients/R2Client.swift
+++ b/FrescoCore/Sources/FrescoCore/Clients/R2Client.swift
@@ -53,10 +53,17 @@ public struct R2Client: R2ClientProtocol, Sendable {
         destinationKey: String,
         cacheControl: String?
     ) async throws(FrescoError) {
+        var contentType: String?
+        if cacheControl != nil {
+            let headResponse = try await headObject(key: sourceKey)
+            contentType = headResponse.value(forHTTPHeaderField: "Content-Type")
+        }
+
         let request = try buildCopyRequest(
             sourceKey: sourceKey,
             destinationKey: destinationKey,
             cacheControl: cacheControl,
+            contentType: contentType,
             date: Date()
         )
 
@@ -75,6 +82,7 @@ public struct R2Client: R2ClientProtocol, Sendable {
         sourceKey: String,
         destinationKey: String,
         cacheControl: String?,
+        contentType: String? = nil,
         date: Date
     ) throws(FrescoError) -> URLRequest {
         let host = "\(accountId).r2.cloudflarestorage.com"
@@ -112,15 +120,30 @@ public struct R2Client: R2ClientProtocol, Sendable {
             request.setValue(cacheControl, forHTTPHeaderField: "Cache-Control")
             request.setValue("REPLACE", forHTTPHeaderField: "x-amz-metadata-directive")
 
-            signedHeaders = "cache-control;host;x-amz-content-sha256;x-amz-copy-source;x-amz-date;x-amz-metadata-directive"
-            canonicalHeaders = [
-                "cache-control:\(cacheControl)",
-                "host:\(host)",
-                "x-amz-content-sha256:\(payloadHash)",
-                "x-amz-copy-source:\(copySource)",
-                "x-amz-date:\(amzDate)",
-                "x-amz-metadata-directive:REPLACE\n",
-            ].joined(separator: "\n")
+            if let contentType {
+                request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+
+                signedHeaders = "cache-control;content-type;host;x-amz-content-sha256;x-amz-copy-source;x-amz-date;x-amz-metadata-directive"
+                canonicalHeaders = [
+                    "cache-control:\(cacheControl)",
+                    "content-type:\(contentType)",
+                    "host:\(host)",
+                    "x-amz-content-sha256:\(payloadHash)",
+                    "x-amz-copy-source:\(copySource)",
+                    "x-amz-date:\(amzDate)",
+                    "x-amz-metadata-directive:REPLACE\n",
+                ].joined(separator: "\n")
+            } else {
+                signedHeaders = "cache-control;host;x-amz-content-sha256;x-amz-copy-source;x-amz-date;x-amz-metadata-directive"
+                canonicalHeaders = [
+                    "cache-control:\(cacheControl)",
+                    "host:\(host)",
+                    "x-amz-content-sha256:\(payloadHash)",
+                    "x-amz-copy-source:\(copySource)",
+                    "x-amz-date:\(amzDate)",
+                    "x-amz-metadata-directive:REPLACE\n",
+                ].joined(separator: "\n")
+            }
         } else {
             signedHeaders = "host;x-amz-content-sha256;x-amz-copy-source;x-amz-date"
             canonicalHeaders = [
@@ -133,6 +156,96 @@ public struct R2Client: R2ClientProtocol, Sendable {
 
         let canonicalRequest = [
             "PUT",
+            path,
+            "",
+            canonicalHeaders,
+            signedHeaders,
+            payloadHash,
+        ].joined(separator: "\n")
+
+        let region = "auto"
+        let service = "s3"
+        let credentialScope = "\(dateStamp)/\(region)/\(service)/aws4_request"
+
+        let stringToSign = [
+            "AWS4-HMAC-SHA256",
+            amzDate,
+            credentialScope,
+            sha256Hex(Data(canonicalRequest.utf8)),
+        ].joined(separator: "\n")
+
+        let signingKey = deriveSigningKey(
+            secretKey: secretAccessKey,
+            dateStamp: dateStamp,
+            region: region,
+            service: service
+        )
+
+        let signature = hmacSHA256Hex(key: signingKey, data: Data(stringToSign.utf8))
+
+        let authorization =
+            "AWS4-HMAC-SHA256 Credential=\(accessKeyId)/\(credentialScope), SignedHeaders=\(signedHeaders), Signature=\(signature)"
+        request.setValue(authorization, forHTTPHeaderField: "Authorization")
+
+        return request
+    }
+
+    private func headObject(key: String) async throws(FrescoError) -> HTTPURLResponse {
+        let request = try buildHeadRequest(key: key, date: Date())
+
+        let response: URLResponse
+        do {
+            (_, response) = try await session.data(for: request)
+        } catch {
+            throw .r2Error("R2 HEAD failed: \(error.localizedDescription)")
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw .r2Error("R2 HEAD failed")
+        }
+
+        return httpResponse
+    }
+
+    func buildHeadRequest(
+        key: String,
+        date: Date
+    ) throws(FrescoError) -> URLRequest {
+        let host = "\(accountId).r2.cloudflarestorage.com"
+
+        guard let baseURL = URL(string: "https://\(host)") else {
+            throw .r2Error("Invalid R2 endpoint URL")
+        }
+
+        let url = baseURL.appendingPathComponent(bucket).appendingPathComponent(key)
+        let path = url.path(percentEncoded: true)
+
+        let amzDate = date.formatted(
+            .iso8601.year().month().day()
+                .time(includingFractionalSeconds: false)
+                .timeSeparator(.omitted).dateSeparator(.omitted)
+                .timeZone(separator: .omitted)
+        )
+        let dateStamp = String(amzDate.prefix(8))
+
+        let payloadHash = sha256Hex(Data())
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "HEAD"
+        request.setValue(host, forHTTPHeaderField: "Host")
+        request.setValue(amzDate, forHTTPHeaderField: "x-amz-date")
+        request.setValue(payloadHash, forHTTPHeaderField: "x-amz-content-sha256")
+
+        let signedHeaders = "host;x-amz-content-sha256;x-amz-date"
+        let canonicalHeaders = [
+            "host:\(host)",
+            "x-amz-content-sha256:\(payloadHash)",
+            "x-amz-date:\(amzDate)\n",
+        ].joined(separator: "\n")
+
+        let canonicalRequest = [
+            "HEAD",
             path,
             "",
             canonicalHeaders,

--- a/FrescoCore/Sources/FrescoCore/Clients/R2Client.swift
+++ b/FrescoCore/Sources/FrescoCore/Clients/R2Client.swift
@@ -85,6 +85,10 @@ public struct R2Client: R2ClientProtocol, Sendable {
         contentType: String? = nil,
         date: Date
     ) throws(FrescoError) -> URLRequest {
+        if contentType != nil && cacheControl == nil {
+            throw .r2Error("contentType requires cacheControl when building a copy request")
+        }
+
         let host = "\(accountId).r2.cloudflarestorage.com"
 
         guard let baseURL = URL(string: "https://\(host)") else {
@@ -193,16 +197,18 @@ public struct R2Client: R2ClientProtocol, Sendable {
     private func headObject(key: String) async throws(FrescoError) -> HTTPURLResponse {
         let request = try buildHeadRequest(key: key, date: Date())
 
+        let responseData: Data
         let response: URLResponse
         do {
-            (_, response) = try await session.data(for: request)
+            (responseData, response) = try await session.data(for: request)
         } catch {
             throw .r2Error("R2 HEAD failed: \(error.localizedDescription)")
         }
 
-        guard let httpResponse = response as? HTTPURLResponse,
-              (200...299).contains(httpResponse.statusCode) else {
-            throw .r2Error("R2 HEAD failed")
+        try handleResponse(data: responseData, response: response)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw .r2Error("R2 HEAD failed: invalid response")
         }
 
         return httpResponse

--- a/FrescoCore/Sources/FrescoCore/Clients/R2Client.swift
+++ b/FrescoCore/Sources/FrescoCore/Clients/R2Client.swift
@@ -5,6 +5,11 @@ import Foundation
 import FoundationNetworking
 #endif
 
+struct MetadataOverride: Sendable {
+    let cacheControl: String
+    let contentType: String
+}
+
 public struct R2Client: R2ClientProtocol, Sendable {
     let accountId: String
     let accessKeyId: String
@@ -53,17 +58,17 @@ public struct R2Client: R2ClientProtocol, Sendable {
         destinationKey: String,
         cacheControl: String?
     ) async throws(FrescoError) {
-        var contentType: String?
-        if cacheControl != nil {
+        var metadataOverride: MetadataOverride?
+        if let cacheControl {
             let headResponse = try await headObject(key: sourceKey)
-            contentType = headResponse.value(forHTTPHeaderField: "Content-Type")
+            let contentType = headResponse.value(forHTTPHeaderField: "Content-Type") ?? "application/octet-stream"
+            metadataOverride = MetadataOverride(cacheControl: cacheControl, contentType: contentType)
         }
 
         let request = try buildCopyRequest(
             sourceKey: sourceKey,
             destinationKey: destinationKey,
-            cacheControl: cacheControl,
-            contentType: contentType,
+            metadataOverride: metadataOverride,
             date: Date()
         )
 
@@ -81,14 +86,9 @@ public struct R2Client: R2ClientProtocol, Sendable {
     func buildCopyRequest(
         sourceKey: String,
         destinationKey: String,
-        cacheControl: String?,
-        contentType: String? = nil,
+        metadataOverride: MetadataOverride? = nil,
         date: Date
     ) throws(FrescoError) -> URLRequest {
-        if contentType != nil && cacheControl == nil {
-            throw .r2Error("contentType requires cacheControl when building a copy request")
-        }
-
         let host = "\(accountId).r2.cloudflarestorage.com"
 
         guard let baseURL = URL(string: "https://\(host)") else {
@@ -120,34 +120,21 @@ public struct R2Client: R2ClientProtocol, Sendable {
         let signedHeaders: String
         let canonicalHeaders: String
 
-        if let cacheControl {
-            request.setValue(cacheControl, forHTTPHeaderField: "Cache-Control")
+        if let metadataOverride {
+            request.setValue(metadataOverride.cacheControl, forHTTPHeaderField: "Cache-Control")
+            request.setValue(metadataOverride.contentType, forHTTPHeaderField: "Content-Type")
             request.setValue("REPLACE", forHTTPHeaderField: "x-amz-metadata-directive")
 
-            if let contentType {
-                request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-
-                signedHeaders = "cache-control;content-type;host;x-amz-content-sha256;x-amz-copy-source;x-amz-date;x-amz-metadata-directive"
-                canonicalHeaders = [
-                    "cache-control:\(cacheControl)",
-                    "content-type:\(contentType)",
-                    "host:\(host)",
-                    "x-amz-content-sha256:\(payloadHash)",
-                    "x-amz-copy-source:\(copySource)",
-                    "x-amz-date:\(amzDate)",
-                    "x-amz-metadata-directive:REPLACE\n",
-                ].joined(separator: "\n")
-            } else {
-                signedHeaders = "cache-control;host;x-amz-content-sha256;x-amz-copy-source;x-amz-date;x-amz-metadata-directive"
-                canonicalHeaders = [
-                    "cache-control:\(cacheControl)",
-                    "host:\(host)",
-                    "x-amz-content-sha256:\(payloadHash)",
-                    "x-amz-copy-source:\(copySource)",
-                    "x-amz-date:\(amzDate)",
-                    "x-amz-metadata-directive:REPLACE\n",
-                ].joined(separator: "\n")
-            }
+            signedHeaders = "cache-control;content-type;host;x-amz-content-sha256;x-amz-copy-source;x-amz-date;x-amz-metadata-directive"
+            canonicalHeaders = [
+                "cache-control:\(metadataOverride.cacheControl)",
+                "content-type:\(metadataOverride.contentType)",
+                "host:\(host)",
+                "x-amz-content-sha256:\(payloadHash)",
+                "x-amz-copy-source:\(copySource)",
+                "x-amz-date:\(amzDate)",
+                "x-amz-metadata-directive:REPLACE\n",
+            ].joined(separator: "\n")
         } else {
             signedHeaders = "host;x-amz-content-sha256;x-amz-copy-source;x-amz-date"
             canonicalHeaders = [

--- a/FrescoCore/Tests/FrescoCoreTests/Clients/R2ClientTests.swift
+++ b/FrescoCore/Tests/FrescoCoreTests/Clients/R2ClientTests.swift
@@ -113,7 +113,6 @@ struct R2ClientTests {
         let request = try client.buildCopyRequest(
             sourceKey: "images/source.jpg",
             destinationKey: "images/dest.jpg",
-            cacheControl: nil,
             date: fixedDate
         )
 
@@ -126,7 +125,6 @@ struct R2ClientTests {
         let request = try client.buildCopyRequest(
             sourceKey: "images/source.jpg",
             destinationKey: "images/dest.jpg",
-            cacheControl: nil,
             date: fixedDate
         )
 
@@ -138,7 +136,6 @@ struct R2ClientTests {
         let request = try client.buildCopyRequest(
             sourceKey: "images/source.jpg",
             destinationKey: "images/dest.jpg",
-            cacheControl: nil,
             date: fixedDate
         )
 
@@ -160,13 +157,11 @@ struct R2ClientTests {
         let request1 = try client.buildCopyRequest(
             sourceKey: "images/source.jpg",
             destinationKey: "images/dest.jpg",
-            cacheControl: nil,
             date: fixedDate
         )
         let request2 = try client.buildCopyRequest(
             sourceKey: "images/source.jpg",
             destinationKey: "images/dest.jpg",
-            cacheControl: nil,
             date: fixedDate
         )
 
@@ -181,7 +176,6 @@ struct R2ClientTests {
         let request = try client.buildCopyRequest(
             sourceKey: "images/my folder/source.jpg",
             destinationKey: "images/dest.jpg",
-            cacheControl: nil,
             date: fixedDate
         )
 
@@ -193,7 +187,7 @@ struct R2ClientTests {
         let request = try client.buildCopyRequest(
             sourceKey: "images/source.jpg",
             destinationKey: "images/dest.jpg",
-            cacheControl: "public, max-age=300",
+            metadataOverride: MetadataOverride(cacheControl: "public, max-age=300", contentType: "image/png"),
             date: fixedDate
         )
 
@@ -205,7 +199,7 @@ struct R2ClientTests {
         let request = try client.buildCopyRequest(
             sourceKey: "images/source.jpg",
             destinationKey: "images/dest.jpg",
-            cacheControl: "public, max-age=300",
+            metadataOverride: MetadataOverride(cacheControl: "public, max-age=300", contentType: "image/png"),
             date: fixedDate
         )
 
@@ -217,13 +211,13 @@ struct R2ClientTests {
         let request = try client.buildCopyRequest(
             sourceKey: "images/source.jpg",
             destinationKey: "images/dest.jpg",
-            cacheControl: "public, max-age=300",
+            metadataOverride: MetadataOverride(cacheControl: "public, max-age=300", contentType: "image/png"),
             date: fixedDate
         )
 
         let auth = request.value(forHTTPHeaderField: "Authorization")
         #expect(
-            auth?.contains("SignedHeaders=cache-control;host;x-amz-content-sha256;x-amz-copy-source;x-amz-date;x-amz-metadata-directive") == true
+            auth?.contains("SignedHeaders=cache-control;content-type;host;x-amz-content-sha256;x-amz-copy-source;x-amz-date;x-amz-metadata-directive") == true
         )
     }
 
@@ -261,8 +255,7 @@ struct R2ClientTests {
         let request = try client.buildCopyRequest(
             sourceKey: "images/source.jpg",
             destinationKey: "images/dest.jpg",
-            cacheControl: "public, max-age=300",
-            contentType: "image/png",
+            metadataOverride: MetadataOverride(cacheControl: "public, max-age=300", contentType: "image/png"),
             date: fixedDate
         )
 
@@ -274,8 +267,7 @@ struct R2ClientTests {
         let request = try client.buildCopyRequest(
             sourceKey: "images/source.jpg",
             destinationKey: "images/dest.jpg",
-            cacheControl: "public, max-age=300",
-            contentType: "image/png",
+            metadataOverride: MetadataOverride(cacheControl: "public, max-age=300", contentType: "image/png"),
             date: fixedDate
         )
 

--- a/FrescoCore/Tests/FrescoCoreTests/Clients/R2ClientTests.swift
+++ b/FrescoCore/Tests/FrescoCoreTests/Clients/R2ClientTests.swift
@@ -227,6 +227,64 @@ struct R2ClientTests {
         )
     }
 
+    @Test func buildHeadRequest_constructsCorrectURL() throws {
+        let client = makeClient()
+        let request = try client.buildHeadRequest(
+            key: "images/source.jpg",
+            date: fixedDate
+        )
+
+        #expect(request.url?.absoluteString == "https://test-account.r2.cloudflarestorage.com/test-bucket/images/source.jpg")
+        #expect(request.httpMethod == "HEAD")
+    }
+
+    @Test func buildHeadRequest_signsWithAWSV4() throws {
+        let client = makeClient()
+        let request = try client.buildHeadRequest(
+            key: "images/source.jpg",
+            date: fixedDate
+        )
+
+        #expect(request.value(forHTTPHeaderField: "x-amz-date") == "20260324T120000Z")
+        #expect(
+            request.value(forHTTPHeaderField: "x-amz-content-sha256")
+                == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+
+        let auth = request.value(forHTTPHeaderField: "Authorization")
+        #expect(auth?.contains("Credential=test-key-id/20260324/auto/s3/aws4_request") == true)
+        #expect(auth?.contains("SignedHeaders=host;x-amz-content-sha256;x-amz-date") == true)
+    }
+
+    @Test func buildCopyRequest_setsContentTypeWhenProvided() throws {
+        let client = makeClient()
+        let request = try client.buildCopyRequest(
+            sourceKey: "images/source.jpg",
+            destinationKey: "images/dest.jpg",
+            cacheControl: "public, max-age=300",
+            contentType: "image/png",
+            date: fixedDate
+        )
+
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "image/png")
+    }
+
+    @Test func buildCopyRequest_includesContentTypeInSignedHeaders() throws {
+        let client = makeClient()
+        let request = try client.buildCopyRequest(
+            sourceKey: "images/source.jpg",
+            destinationKey: "images/dest.jpg",
+            cacheControl: "public, max-age=300",
+            contentType: "image/png",
+            date: fixedDate
+        )
+
+        let auth = request.value(forHTTPHeaderField: "Authorization")
+        #expect(
+            auth?.contains("SignedHeaders=cache-control;content-type;host;x-amz-content-sha256;x-amz-copy-source;x-amz-date;x-amz-metadata-directive") == true
+        )
+    }
+
     @Test func handleResponse_successDoesNotThrow() throws {
         let client = makeClient()
         let url = URL(string: "https://example.com")!


### PR DESCRIPTION
## Summary

- HEAD the source object before CopyObject with `MetadataDirective: REPLACE` to retrieve its `Content-Type`
- Include `Content-Type` on the copy request so REPLACE doesn't drop it
- `buildHeadRequest` follows the same AWS V4 signing pattern as existing request builders
- `headObject` is private to `R2Client` — no protocol or mock changes needed

Closes #129

## Test plan

- [x] `buildHeadRequest` constructs correct URL and uses HEAD method
- [x] `buildHeadRequest` signs with AWS V4 (correct signed headers)
- [x] `buildCopyRequest` sets Content-Type header when provided
- [x] `buildCopyRequest` includes content-type in signed headers when provided