### PR TITLE
Add --cache-control flag to upload command

### DIFF
--- a/FrescoCLI/Sources/FrescoCLI/Commands/UploadCommand.swift
+++ b/FrescoCLI/Sources/FrescoCLI/Commands/UploadCommand.swift
@@ -33,6 +33,9 @@ struct UploadCommand: AsyncParsableCommand {
     @Option(name: .long, help: "R2 public base URL for uploaded images")
     var r2PublicBaseUrl: String?
 
+    @Option(name: .long, help: "Cache-Control header for the uploaded object")
+    var cacheControl: String?
+
     struct Dependencies: Sendable {
         let configReader: ConfigReader
         let r2: any R2ClientProtocol
@@ -49,6 +52,7 @@ struct UploadCommand: AsyncParsableCommand {
         case r2SecretAccessKey
         case r2Bucket
         case r2PublicBaseUrl
+        case cacheControl
     }
 
     mutating func run() async throws {
@@ -70,7 +74,12 @@ struct UploadCommand: AsyncParsableCommand {
         }
 
         let service = UploadService(r2: deps.r2, publicBaseURL: effectiveR2PublicBaseUrl)
-        let result = try await service.upload(filePath: filePath, slug: effectiveSlug, destinationFilename: destinationFilename)
+        let result: UploadResult
+        if let cacheControl {
+            result = try await service.upload(filePath: filePath, slug: effectiveSlug, destinationFilename: destinationFilename, cacheControl: cacheControl)
+        } else {
+            result = try await service.upload(filePath: filePath, slug: effectiveSlug, destinationFilename: destinationFilename)
+        }
 
         print(result.publicURL.absoluteString)
     }

--- a/FrescoCLI/Tests/FrescoCLITests/Commands/UploadCommandTests.swift
+++ b/FrescoCLI/Tests/FrescoCLITests/Commands/UploadCommandTests.swift
@@ -112,6 +112,39 @@ struct UploadCommandTests {
         #expect(receivedKey.withLock { $0 } == "test-slug/latest.jpg")
     }
 
+    @Test func command_parsesCacheControlFlag() throws {
+        let cmd = try UploadCommand.parse([
+            "/tmp/test/image.jpg", "--cache-control", "public, max-age=300",
+        ])
+        #expect(cmd.cacheControl == "public, max-age=300")
+    }
+
+    @Test func command_cacheControlDefaultsToNil() throws {
+        let cmd = try UploadCommand.parse(["/tmp/test/image.jpg"])
+        #expect(cmd.cacheControl == nil)
+    }
+
+    @Test func run_passesCacheControlToService() async throws {
+        let (filePath, tmpSlug) = try writeTempFile()
+        defer { try? FileManager.default.removeItem(atPath: "/tmp/\(tmpSlug)") }
+
+        let receivedCacheControl = Mutex<String?>(nil)
+        var cmd = try UploadCommand.parse([
+            filePath, "--cache-control", "public, max-age=300",
+        ])
+        cmd.overrideDependencies = UploadCommand.Dependencies(
+            configReader: ConfigReader(provider: InMemoryProvider(values: [
+                "frescoSlug": "test-slug",
+                "r2.publicBaseUrl": "https://cdn.example.com",
+            ])),
+            r2: MockCLIR2Client(onUpload: { _, _, _, cacheControl in
+                receivedCacheControl.withLock { $0 = cacheControl }
+            })
+        )
+        try await cmd.run()
+        #expect(receivedCacheControl.withLock { $0 } == "public, max-age=300")
+    }
+
     @Test func run_throwsWhenSlugMissing() async throws {
         let (filePath, tmpSlug) = try writeTempFile()
         defer { try? FileManager.default.removeItem(atPath: "/tmp/\(tmpSlug)") }

--- a/FrescoCore/Sources/FrescoCore/Services/UploadService.swift
+++ b/FrescoCore/Sources/FrescoCore/Services/UploadService.swift
@@ -9,7 +9,7 @@ public struct UploadService: Sendable {
         self.publicBaseURL = publicBaseURL
     }
 
-    public func upload(filePath: String, slug: String, destinationFilename: String? = nil) async throws(FrescoError) -> UploadResult {
+    public func upload(filePath: String, slug: String, destinationFilename: String? = nil, cacheControl: String = "public, max-age=31536000") async throws(FrescoError) -> UploadResult {
         let slug = try SlugValidator.validate(slug)
 
         guard
@@ -49,7 +49,7 @@ public struct UploadService: Sendable {
             data: data,
             key: key,
             contentType: format.contentType,
-            cacheControl: "public, max-age=31536000"
+            cacheControl: cacheControl
         )
 
         let publicURL = baseURL

--- a/FrescoCore/Tests/FrescoCoreTests/Services/UploadServiceTests.swift
+++ b/FrescoCore/Tests/FrescoCoreTests/Services/UploadServiceTests.swift
@@ -254,6 +254,47 @@ struct UploadServiceTests {
         }
     }
 
+    @Test("upload uses custom cacheControl when provided")
+    func uploadUsesCustomCacheControl() async throws {
+        let (filePath, tmpSlug) = try writeTempFile()
+        defer { try? FileManager.default.removeItem(atPath: "/tmp/\(tmpSlug)") }
+
+        let receivedCacheControl = Mutex<String?>(nil)
+        let r2 = MockR2Client(onUpload: { _, _, _, cacheControl in
+            receivedCacheControl.withLock { $0 = cacheControl }
+        })
+
+        let service = UploadService(r2: r2, publicBaseURL: Self.testPublicBaseURL)
+
+        _ = try await service.upload(
+            filePath: filePath,
+            slug: Self.testSlug,
+            cacheControl: "public, max-age=300"
+        )
+
+        #expect(receivedCacheControl.withLock { $0 } == "public, max-age=300")
+    }
+
+    @Test("upload uses default cacheControl when not provided")
+    func uploadUsesDefaultCacheControl() async throws {
+        let (filePath, tmpSlug) = try writeTempFile()
+        defer { try? FileManager.default.removeItem(atPath: "/tmp/\(tmpSlug)") }
+
+        let receivedCacheControl = Mutex<String?>(nil)
+        let r2 = MockR2Client(onUpload: { _, _, _, cacheControl in
+            receivedCacheControl.withLock { $0 = cacheControl }
+        })
+
+        let service = UploadService(r2: r2, publicBaseURL: Self.testPublicBaseURL)
+
+        _ = try await service.upload(
+            filePath: filePath,
+            slug: Self.testSlug
+        )
+
+        #expect(receivedCacheControl.withLock { $0 } == "public, max-age=31536000")
+    }
+
     @Test("upload throws on invalid slug")
     func uploadThrowsOnInvalidSlug() async throws {
         let (filePath, tmpSlug) = try writeTempFile()


### PR DESCRIPTION
## Summary

- Adds optional `--cache-control` flag to `fresco upload`
- When provided, overrides the default `public, max-age=31536000` cache policy
- When omitted, default behavior is unchanged

Closes #126

## Test plan

- [x] UploadService passes custom cacheControl to R2 client
- [x] UploadService uses default cacheControl when not provided
- [x] UploadCommand parses `--cache-control` flag
- [x] UploadCommand defaults cacheControl to nil
- [x] UploadCommand passes cacheControl to service