### PR TITLE
Set 5-minute cache on latest alias in workflow

### DIFF
--- a/.github/workflows/fresco.yml
+++ b/.github/workflows/fresco.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           URL="${{ steps.fresco.outputs.url }}"
           FILENAME=$(basename "$URL")
-          fresco remote copy "$FILENAME" "latest"
+          fresco remote copy "$FILENAME" "latest" --cache-control "public, max-age=300"
         env:
           FRESCO_SLUG:         ${{ secrets.FRESCO_SLUG }}
           R2_ACCOUNT_ID:       ${{ secrets.R2_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- Passes `--cache-control "public, max-age=300"` to the `fresco remote copy` step in the dogfooding workflow
- The `latest` URL will now refresh within 5 minutes of a new release instead of being cached for a year

Closes #127