### PR TITLE
Document --cache-control flag in docs and examples

### DIFF
--- a/Examples/steps-latest-alias.yml
+++ b/Examples/steps-latest-alias.yml
@@ -31,7 +31,7 @@
         run: |
           URL="${{ steps.fresco.outputs.url }}"
           FILENAME=$(basename "$URL")
-          fresco remote copy "$FILENAME" "latest.${FILENAME##*.}"
+          fresco remote copy "$FILENAME" "latest.${FILENAME##*.}" --cache-control "public, max-age=300"
         env:
           FRESCO_SLUG:           ${{ secrets.FRESCO_SLUG }}
           R2_ACCOUNT_ID:         ${{ secrets.R2_ACCOUNT_ID }}

--- a/Examples/steps-latest-extensionless.yml
+++ b/Examples/steps-latest-extensionless.yml
@@ -32,7 +32,7 @@
         run: |
           URL="${{ steps.fresco.outputs.url }}"
           FILENAME=$(basename "$URL")
-          fresco remote copy "$FILENAME" latest
+          fresco remote copy "$FILENAME" latest --cache-control "public, max-age=300"
         env:
           FRESCO_SLUG:           ${{ secrets.FRESCO_SLUG }}
           R2_ACCOUNT_ID:         ${{ secrets.R2_ACCOUNT_ID }}

--- a/FrescoDocs/CLI.md
+++ b/FrescoDocs/CLI.md
@@ -78,6 +78,7 @@ fresco upload <file> [destination]
 | `--r2-secret-access-key <key>` | Override `R2_SECRET_ACCESS_KEY` |
 | `--r2-bucket <name>` | Override `R2_BUCKET` |
 | `--r2-public-base-url <url>` | Override `R2_PUBLIC_BASE_URL` |
+| `--cache-control <value>` | Cache-Control header (default: `public, max-age=31536000`) |
 
 **Examples:**
 
@@ -87,6 +88,9 @@ fresco upload /tmp/my-project/2026-04-02-120000.png
 
 # Upload as a specific filename
 fresco upload /tmp/my-project/2026-04-02-120000.png latest.png
+
+# Upload with a custom cache policy
+fresco upload /tmp/my-project/2026-04-02-120000.png --cache-control "public, max-age=300"
 ```
 
 ---
@@ -120,12 +124,16 @@ fresco remote copy <source> <destination>
 | `--r2-secret-access-key <key>` | Override `R2_SECRET_ACCESS_KEY` |
 | `--r2-bucket <name>` | Override `R2_BUCKET` |
 | `--r2-public-base-url <url>` | Override `R2_PUBLIC_BASE_URL` |
+| `--cache-control <value>` | Cache-Control header for the destination (default: inherit source metadata) |
 
 **Examples:**
 
 ```bash
 # Alias a dated image to latest.png
 fresco remote copy 2026-04-02-120000.png latest.png
+
+# Copy with a short cache TTL for stable aliases
+fresco remote copy 2026-04-02-120000.png latest.png --cache-control "public, max-age=300"
 ```
 
 ---
@@ -147,7 +155,7 @@ fresco upload $(fresco generate)
 # Generate, upload dated, then alias to latest (preserves extension)
 IMAGE=$(fresco generate)
 fresco upload "$IMAGE"
-fresco remote copy "$(basename "$IMAGE")" "latest.${IMAGE##*.}"
+fresco remote copy "$(basename "$IMAGE")" "latest.${IMAGE##*.}" --cache-control "public, max-age=300"
 ```
 
 **Event-driven usage:** The commands can be called from any workflow trigger. For example, to generate a release image:

--- a/FrescoDocs/README.md
+++ b/FrescoDocs/README.md
@@ -20,7 +20,7 @@ fresco upload $(fresco generate)
 # Generate, upload, then alias to a stable URL (preserves extension)
 IMAGE=$(fresco generate)
 fresco upload "$IMAGE"
-fresco remote copy "$(basename "$IMAGE")" "latest.${IMAGE##*.}"
+fresco remote copy "$(basename "$IMAGE")" "latest.${IMAGE##*.}" --cache-control "public, max-age=300"
 ```
 
 Your project points at the stable URL:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ See [`fresco.template.env`](fresco.template.env) for the full variable list.
 | `--r2-secret-access-key` | `R2_SECRET_ACCESS_KEY` | R2 secret access key |
 | `--r2-bucket` | `R2_BUCKET` | R2 bucket name |
 | `--r2-public-base-url` | `R2_PUBLIC_BASE_URL` | Public base URL for R2 images |
-| `--cache-control` | — | Cache-Control header (default: `public, max-age=31536000`) |
+| `--cache-control` | — | Cache-Control header (`upload` default: `public, max-age=31536000`; `remote copy` inherits source metadata if omitted) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ fresco generate --append "Celebrating release v2.1.0"    # extend configured pro
 Uploads a local image to R2. Prints the public URL.
 
 ```bash
-fresco upload /tmp/my-project/2026-04-02-120000.png             # keep original filename
-fresco upload /tmp/my-project/2026-04-02-120000.png latest.png  # upload as latest.png
+fresco upload /tmp/my-project/2026-04-02-120000.png                                        # keep original filename
+fresco upload /tmp/my-project/2026-04-02-120000.png latest.png                               # upload as latest.png
+fresco upload /tmp/my-project/2026-04-02-120000.png --cache-control "public, max-age=300"    # custom cache policy
 ```
 
 R2 key and public URL are composed as:
@@ -68,6 +69,7 @@ Copies an object within R2 (server-side, no download).
 
 ```bash
 fresco remote copy 2026-04-02-120000.png latest.png
+fresco remote copy 2026-04-02-120000.png latest.png --cache-control "public, max-age=300"  # override cache policy
 ```
 
 ### Composable workflows
@@ -87,7 +89,7 @@ fresco upload $(fresco generate)
 # Generate, upload dated, then alias to latest (preserves extension)
 IMAGE=$(fresco generate)
 fresco upload "$IMAGE"
-fresco remote copy "$(basename "$IMAGE")" "latest.${IMAGE##*.}"
+fresco remote copy "$(basename "$IMAGE")" "latest.${IMAGE##*.}" --cache-control "public, max-age=300"
 ```
 
 Use `basename` to extract the filename from a local path, and `${IMAGE##*.}` to extract the extension — this ensures the stable alias always matches the actual image format.
@@ -118,6 +120,7 @@ See [`fresco.template.env`](fresco.template.env) for the full variable list.
 | `--r2-secret-access-key` | `R2_SECRET_ACCESS_KEY` | R2 secret access key |
 | `--r2-bucket` | `R2_BUCKET` | R2 bucket name |
 | `--r2-public-base-url` | `R2_PUBLIC_BASE_URL` | Public base URL for R2 images |
+| `--cache-control` | — | Cache-Control header (default: `public, max-age=31536000`) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `--cache-control` flag to upload and remote copy docs in README, CLI reference, and FrescoDocs
- Update example workflow snippets to pass `--cache-control "public, max-age=300"` on copy steps
- Add `--cache-control` to the configuration flags table in README

Closes #124