### PR TITLE
Refactor Fresco into reusable workflow with manual dispatch

### DIFF
--- a/.github/workflows/fresco-release.yml
+++ b/.github/workflows/fresco-release.yml
@@ -1,0 +1,16 @@
+name: Fresco (release)
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fresco:
+    if: github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/fresco.yml
+    secrets: inherit

--- a/.github/workflows/fresco.yml
+++ b/.github/workflows/fresco.yml
@@ -1,9 +1,8 @@
 name: Fresco
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
+  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: write
@@ -16,7 +15,6 @@ concurrency:
 jobs:
   fresco:
     name: Generate and publish
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- `fresco.yml` now supports both `workflow_dispatch` (manual) and `workflow_call` (reusable)
- New `fresco-release.yml` is a thin wrapper that triggers on Release completion and calls `fresco.yml`
- All logic stays in one place — new triggers just add a wrapper file

Closes #122
Closes #121